### PR TITLE
fix gulp not init sasscss first

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -150,7 +150,7 @@ gulp.task('watchsass',function () {
 })
 
 gulp.task('sasscss', function () {
-        sass('src/sass/')
+        sass('src/sass/*')
         .on('error', function (err) {
             console.error('Error!', err.message);
         })


### PR DESCRIPTION
lack of `*` to match files